### PR TITLE
Start installed executable after install

### DIFF
--- a/MultiTeams/ContextMenu.cs
+++ b/MultiTeams/ContextMenu.cs
@@ -8,6 +8,7 @@
 using MultiTeams.Utils;
 using MultiTeams.WindowsNative;
 using System;
+using System.Diagnostics;
 using System.Linq;
 
 namespace MultiTeams
@@ -61,13 +62,18 @@ namespace MultiTeams
 
             var ExitItem = ToolStripBuilder.Button("Exit", (sender, e) =>
             {
-                _icon.Visible = false;
-                _app?.Dispose();
-                Application.Exit();
+                ApplicationExit();
             });
             menu.Items.Add(ExitItem);
 
             return menu;
+        }
+
+        private void ApplicationExit()
+        {
+            _icon.Visible = false;
+            _app?.Dispose();
+            Application.Exit();
         }
 
         private ToolStripMenuItem SettingsMenuBuild()
@@ -100,6 +106,12 @@ namespace MultiTeams
                 {
                     _installer.Install();
                     _installer.AutostartEnable();
+                    if (!_installer.IsInstalledExe)
+                    {
+                        var exe = Path.Combine(_installer.InstallDir, Path.GetFileName(Application.ExecutablePath));
+                        ProcessLauncher.Start(exe, $"/new");
+                        ApplicationExit();
+                    }
                 }
                 else
                 {

--- a/MultiTeams/MultiTeamsApp.cs
+++ b/MultiTeams/MultiTeamsApp.cs
@@ -75,10 +75,7 @@ namespace MultiTeams
             _menu.DropDownItems.Add(ToolStripBuilder.Button("Add...", OnAddInstance_Click));
             _menu.DropDownItems.Add(ToolStripBuilder.Button("Reveal config file in explorer...", (sender, args) =>
             {
-                using Process myProcess = new Process();
-                myProcess.StartInfo.FileName = "explorer.exe";
-                myProcess.StartInfo.Arguments = $"/select, \"{_service.ConfigPath}\"";
-                myProcess.Start();
+                ProcessLauncher.Start("explorer.exe", $"/select, \"{_service.ConfigPath}\"");
             }));
         }
 

--- a/MultiTeams/Utils/ProcessLauncher.cs
+++ b/MultiTeams/Utils/ProcessLauncher.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace MultiTeams.Utils
+{
+    internal static class ProcessLauncher
+    {
+        /// <inheritdoc cref="Process.Start"/>
+        public static bool Start(string exe, string args)
+        {
+            using Process myProcess = new Process();
+            myProcess.StartInfo.FileName = exe;
+            myProcess.StartInfo.Arguments = args;
+            return myProcess.Start();
+        }
+    }
+}


### PR DESCRIPTION
This guarantees the correct setup source (config file) is being used after installation. Otherwise, the user is at risk of creating a configuration that is not transferred to the installation directory anymore.